### PR TITLE
chore: Railway API URL 적용 준비

### DIFF
--- a/.env.example
+++ b/.env.example
@@ -1,0 +1,1 @@
+VITE_API_URL=https://tickit-server-production.up.railway.app

--- a/vite.config.ts
+++ b/vite.config.ts
@@ -43,6 +43,9 @@ export default defineConfig(({ mode }) => {
         {
           entry: 'src/main.ts',
           vite: { 
+            define: {
+              'process.env.VITE_API_URL': JSON.stringify(env.VITE_API_URL),
+            },
             build: { 
               outDir: 'dist-electron/main',
               rollupOptions: {


### PR DESCRIPTION
## 작업 내용

Closes #17

프론트엔드가 로컬 백엔드 대신 Railway 백엔드를 바라볼 수 있도록 환경 설정을 정리했습니다.

- Railway 백엔드 URL을 `.env.example`에 문서화
- Electron main build에서도 `VITE_API_URL`이 주입되도록 `vite.config.ts` 설정 추가
- Google OAuth 진입 URL이 `localhost:3000` fallback을 타지 않고 Railway 서버를 바라보도록 수정

## Railway API URL

```env
VITE_API_URL=https://tickit-server-production.up.railway.app
```

로컬 `.env`에도 위 값을 적용하면 로컬 백엔드 없이 Railway 서버 기준으로 테스트할 수 있습니다.

## 확인한 내용

- Railway `/api` 응답 확인
- Railway `/api/docs-json` 응답 확인
- `npm exec orval` 실행 확인
- `npm run build` 통과
- 빌드된 Electron main 번들에서 Google OAuth URL이 Railway 서버로 주입되는 것 확인

## 참고

Railway 배포본의 OpenAPI 스펙에는 현재 sync 관련 항목이 포함되어 있지 않아, 이번 PR에서는 orval generated file 변경을 포함하지 않았습니다.

## 테스트

- [x] `npm run build`
- [x] Google 로그인 버튼이 `https://tickit-server-production.up.railway.app/api/auth/google`로 이동하는지 확인
- [ ] Railway 서버 기준 로그인 / 회원가입 / 로그아웃 / CRUD 수동 확인

## Google OAuth 설정 필요

Google Cloud Console의 OAuth Client에 아래 redirect URI가 등록되어 있어야 합니다.

```txt
https://tickit-server-production.up.railway.app/api/auth/google/callback
```

로컬 개발을 계속 지원하려면 기존 localhost redirect URI도 유지합니다.