### PR TITLE
ci: GitHub Actions 릴리즈 자동화 설정

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -1,41 +1,43 @@
-name: Build/Release Tickit
+name: Release Tickit
 
 on:
   push:
     tags:
       - 'v*'
 
-# 릴리스 생성을 위해 쓰기 권한을 명시적으로 부여합니다.
 permissions:
   contents: write
 
 jobs:
   release:
+    name: Build and publish (${{ matrix.os }})
     runs-on: ${{ matrix.os }}
 
     strategy:
-      fail-fast: false # 한 운영체제에서 실패해도 다른 쪽은 계속 진행하도록 설정
+      fail-fast: false
       matrix:
         os: [macos-latest, windows-latest]
 
     steps:
-      - name: Checkout Code
+      - name: Checkout repository
         uses: actions/checkout@v4
 
       - name: Setup Node.js
         uses: actions/setup-node@v4
         with:
-          node-version: 22 # 더 최신인 22 버전으로 상향
-          cache: 'npm'
+          node-version: 22
+          cache: npm
 
-      - name: Install Dependencies
-        run: npm install
+      - name: Install dependencies
+        run: npm ci
 
-      - name: Build Assets
+      - name: Run tests
+        run: npm test
+
+      - name: Build renderer and main process
         run: npm run build
 
-      - name: Build and Publish Application
+      - name: Build and publish app
         env:
           GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}
-        run: |
-          npx electron-builder --publish always
+        run: npx electron-builder --publish always

--- a/package.json
+++ b/package.json
@@ -8,7 +8,7 @@
   "license": "ISC",
   "repository": {
     "type": "git",
-    "url": "https://github.com/soprue/vanilla-reminder.git"
+    "url": "https://github.com/soprue/tickit-app.git"
   },
   "scripts": {
     "dev": "vite",
@@ -65,7 +65,7 @@
       {
         "provider": "github",
         "owner": "soprue",
-        "repo": "vanilla-reminder"
+        "repo": "tickit-app"
       }
     ]
   },


### PR DESCRIPTION
## 작업 내용

- 릴리즈용 GitHub Actions 워크플로를 재작성했습니다.
- `v*` 태그 푸시 시 macOS, Windows 환경에서 앱 빌드가 실행되도록 설정했습니다.
- CI 단계에 `npm ci`, `npm test`, `npm run build`를 추가했습니다.
- `electron-builder --publish always`로 빌드 산출물을 GitHub Release에 업로드하도록 설정했습니다.
- `package.json`의 GitHub Release 대상 저장소를 `soprue/tickit-app`으로 수정했습니다.

## 확인한 내용

- `npm test` 통과
- `npm run build` 통과

## 참고

- 로컬에서는 `npm ci`가 Windows Tailwind native 파일 삭제 권한 문제로 실패했습니다.
- `npm install`로 의존성을 복구한 뒤 테스트와 빌드를 확인했습니다.
- 실제 릴리즈 검증은 머지 후 `v*` 태그 푸시로 확인해야 합니다.

close #19