### PR TITLE
fix: electron-builder 패키징 파일 설정 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -27,6 +27,7 @@
     },
     "files": [
       "dist/**/*",
+      "dist-electron/**/*",
       "src/assets/**/*",
       "preload.cjs"
     ],


### PR DESCRIPTION
## 작업 내용

- `electron-builder` 패키징 대상 파일에 `dist-electron/**/*`를 추가했습니다.
- GitHub Actions 릴리즈 실행 중 `Application entry file dist-electron/main/main.js ... does not exist` 오류가 발생한 원인을 수정했습니다.

## 확인한 내용

- `npm test` 통과
- `npm run build` 통과
- 로컬 `npx electron-builder --win --publish never` 실행 시 기존 진입점 누락 오류는 통과했습니다.

## 참고

- 로컬 Windows에서는 이후 `winCodeSign` 캐시 압축 해제 중 심볼릭 링크 생성 권한 문제로 중단되었습니다.
- PR 머지 후 기존 실패 태그 `v1.0.0`을 삭제/재생성해서 릴리즈 workflow를 다시 검증해야 합니다.

related #19