### PR TITLE
chore: 앱 버전 1.0.1로 변경

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "tickit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "tickit",
-      "version": "1.0.0",
+      "version": "1.0.1",
       "license": "ISC",
       "dependencies": {
         "@tanstack/react-query": "^5.100.10",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "tickit",
   "productName": "Tickit",
-  "version": "1.0.0",
+  "version": "1.0.1",
   "description": "A simple desktop app for reminders, tasks, and schedules.",
   "main": "dist-electron/main/main.js",
   "author": "soprue",


### PR DESCRIPTION
## 작업 내용

- 앱 버전을 `1.0.0`에서 `1.0.1`로 변경했습니다.
- `package-lock.json`의 루트 버전도 함께 맞췄습니다.

## 배경

- `v1.0.1` 태그로 릴리즈 workflow는 성공했지만, `package.json` 버전이 `1.0.0`이라 electron-builder가 새 `v1.0.1` 릴리즈를 만들지 않았습니다.
- `v1.0.1` 릴리즈를 정상 생성하려면 앱 버전과 태그 버전이 일치해야 합니다.

## 다음 단계

- PR 머지 후 기존 `v1.0.1` 태그를 삭제하고, 머지 커밋에 다시 생성해 릴리즈 workflow를 재실행합니다.

related #19