### PR TITLE
fix: 프로토콜 앱 표시명 수정

### DIFF
--- a/package.json
+++ b/package.json
@@ -2,7 +2,7 @@
   "name": "tickit",
   "productName": "Tickit",
   "version": "1.0.1",
-  "description": "A simple desktop app for reminders, tasks, and schedules.",
+  "description": "Tickit Reminder",
   "main": "dist-electron/main/main.js",
   "author": "soprue",
   "license": "ISC",
@@ -51,7 +51,7 @@
       "icon": "src/assets/logo.ico",
       "protocols": [
         {
-          "name": "tickit",
+          "name": "Tickit",
           "schemes": [
             "tickit"
           ]


### PR DESCRIPTION
## 작업 내용

- 브라우저의 커스텀 프로토콜 앱 열기 팝업에 긴 설명문이 노출되지 않도록 앱 description을 `Tickit Reminder`로 변경했습니다.
- Windows 프로토콜 핸들러 표시명을 `tickit`에서 `Tickit`으로 변경했습니다.

## 확인한 내용

- `npm test` 통과
- `npm run build` 통과

## 참고

- 변경 후 새 릴리즈 빌드를 설치해야 Windows 프로토콜 등록 정보가 갱신됩니다.
- 기존 설치 앱은 제거 후 새 설치 파일로 다시 설치하는 것이 가장 확실합니다.

related #19